### PR TITLE
🎒 Safely support Backpacked storage menus

### DIFF
--- a/src/client/java/me/timvinci/terrastorage/mixin/client/AbstractContainerScreenMixin.java
+++ b/src/client/java/me/timvinci/terrastorage/mixin/client/AbstractContainerScreenMixin.java
@@ -66,7 +66,8 @@ public abstract class AbstractContainerScreenMixin<T extends AbstractContainerMe
         // Return if the player is in spectator mode, or if the handled screen is that of the player's inventory.
         if (Minecraft.getInstance().player.isSpectator() ||
             menu instanceof CreativeModeInventoryScreen.ItemPickerMenu ||
-            menu instanceof InventoryMenu) {
+            menu instanceof InventoryMenu ||
+            StorageMenuCompatibility.shouldSkipStorageActions(menu)) {
             return;
         }
 
@@ -116,7 +117,7 @@ public abstract class AbstractContainerScreenMixin<T extends AbstractContainerMe
         }
 
         boolean isEnderChest = menu instanceof ChestMenu && this.getTitle().equals(Component.translatable("container.enderchest"));
-        StorageAction[] buttonActions = StorageAction.getButtonsActions(isEnderChest);
+        StorageAction[] buttonActions = StorageMenuCompatibility.getCompatibleButtonActions(menu, isEnderChest);
 
         ButtonsStyle buttonsStyle = ClientConfigManager.getInstance().getConfig().getButtonsStyle();
         // Set the buttons offset.
@@ -202,7 +203,7 @@ public abstract class AbstractContainerScreenMixin<T extends AbstractContainerMe
      */
     @Inject(method = "mouseClicked", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
     private void mouseClickedTail(MouseButtonEvent click, boolean doubled, CallbackInfoReturnable<Boolean> cir, boolean bl, Slot slot) {
-        if (slot == null || slot.container.getContainerSize() < 27) {
+        if (slot == null || slot.container.getContainerSize() < 27 || StorageMenuCompatibility.shouldSkipStorageActions(menu)) {
             return;
         }
 
@@ -225,7 +226,7 @@ public abstract class AbstractContainerScreenMixin<T extends AbstractContainerMe
      */
     @Inject(method = "keyPressed", at = @At("TAIL"))
     private void onKeyPressed(KeyEvent input, CallbackInfoReturnable<Boolean> cir) {
-        if (hoveredSlot == null || hoveredSlot.container.getContainerSize() < 27) {
+        if (hoveredSlot == null || hoveredSlot.container.getContainerSize() < 27 || StorageMenuCompatibility.shouldSkipStorageActions(menu)) {
             return;
         }
 

--- a/src/main/java/me/timvinci/terrastorage/inventory/InventoryUtils.java
+++ b/src/main/java/me/timvinci/terrastorage/inventory/InventoryUtils.java
@@ -50,24 +50,49 @@ public class InventoryUtils {
      * @param receiverState An InventoryState object of the receiver inventory.
      * @param stack The stack to transfer.
      */
-    public static void transferStack(Container to, InventoryState receiverState, ItemStack stack) {
+    public static boolean transferStack(Container to, InventoryState receiverState, ItemStack stack) {
+        if (stack.isEmpty()) {
+            return false;
+        }
+
+        int initialCount = stack.getCount();
         StackIdentifier stackIdentifier = new StackIdentifier(stack);
 
         // Attempt to transfer the stack to an existing item stack of the same item.
         if (receiverState.getNonFullItemSlots().containsKey(stackIdentifier) && transferToExistingStack(to, receiverState, stack)) {
-            return;
+            return true;
         }
 
-        if (!receiverState.getEmptySlots().isEmpty()) {
+        while (!stack.isEmpty() && !receiverState.getEmptySlots().isEmpty()) {
             int emptySlot = receiverState.getEmptySlots().poll();
-            to.setItem(emptySlot, stack.copyAndClear());
+            if (!to.getItem(emptySlot).isEmpty() || !to.canPlaceItem(emptySlot, stack)) {
+                continue;
+            }
+
+            int transferAmount = Math.min(stack.getCount(), to.getMaxStackSize(stack));
+            if (transferAmount <= 0) {
+                continue;
+            }
+
+            ItemStack transferredStack = stack.copy();
+            transferredStack.setCount(transferAmount);
+            to.setItem(emptySlot, transferredStack);
+
+            ItemStack insertedStack = to.getItem(emptySlot);
+            if (insertedStack.isEmpty()) {
+                continue;
+            }
+
+            stack.shrink(insertedStack.getCount());
             receiverState.setModified();
             // Check if the stack that was transferred isn't full.
-            if (stack.getCount() != stack.getMaxStackSize()) {
+            if (insertedStack.getCount() < Math.min(insertedStack.getMaxStackSize(), to.getMaxStackSize(insertedStack))) {
                 // Add this slot to the item slots of the receiver state.
-                receiverState.getNonFullItemSlots().computeIfAbsent(stackIdentifier, k -> new ArrayList<>()).add(emptySlot);
+                receiverState.getNonFullItemSlots().computeIfAbsent(new StackIdentifier(insertedStack), k -> new ArrayList<>()).add(emptySlot);
             }
         }
+
+        return stack.getCount() != initialCount;
     }
 
     /**
@@ -86,8 +111,17 @@ public class InventoryUtils {
         while (slotsIterator.hasNext() && !stackToTransfer.isEmpty()) {
             int slotWithItem = slotsIterator.next();
             ItemStack existingStack = to.getItem(slotWithItem);
+            if (existingStack.isEmpty() || !to.canPlaceItem(slotWithItem, stackToTransfer)) {
+                slotsIterator.remove();
+                continue;
+            }
 
-            int spaceLeft = existingStack.getMaxStackSize() - existingStack.getCount();
+            int spaceLeft = Math.min(existingStack.getMaxStackSize(), to.getMaxStackSize(existingStack)) - existingStack.getCount();
+            if (spaceLeft <= 0) {
+                slotsIterator.remove();
+                continue;
+            }
+
             int transferAmount;
             // Check if the about to be combined stack will be a full stack.
             if (spaceLeft <= stackToTransfer.getCount()) {
@@ -447,12 +481,16 @@ public class InventoryUtils {
                         return storageInventoryState.getNonFullItemSlots().containsKey(stackIdentifier) ||
                                 ((ExpandedInventoryState)storageInventoryState).getStoredItems().contains(stackIdentifier) && !storageInventoryState.getEmptySlots().isEmpty();
                     },
-                    (stack) -> InventoryUtils.transferStack(storageInventory, storageInventoryState, stack)
+                    stack -> InventoryUtils.transferStack(storageInventory, storageInventoryState, stack)
             ) :
             new StackProcessor(
                     stack -> !stack.isEmpty() &&
                             storageInventoryState.getNonFullItemSlots().containsKey(new StackIdentifier(stack)),
-                    (stack) -> InventoryUtils.transferToExistingStack(storageInventory, storageInventoryState, stack)
+                    stack -> {
+                        int initialCount = stack.getCount();
+                        InventoryUtils.transferToExistingStack(storageInventory, storageInventoryState, stack);
+                        return stack.getCount() != initialCount;
+                    }
             );
     }
 

--- a/src/main/java/me/timvinci/terrastorage/inventory/SlotBackedInventory.java
+++ b/src/main/java/me/timvinci/terrastorage/inventory/SlotBackedInventory.java
@@ -54,7 +54,16 @@ public class SlotBackedInventory implements Container {
 
     @Override
     public void setItem(int slot, ItemStack stack) {
+        if (!stack.isEmpty() && !this.slots.get(slot).mayPlace(stack)) {
+            return;
+        }
+
         this.slots.get(slot).setByPlayer(stack);
+    }
+
+    @Override
+    public boolean canPlaceItem(int slot, ItemStack stack) {
+        return this.slots.get(slot).mayPlace(stack);
     }
 
     @Override

--- a/src/main/java/me/timvinci/terrastorage/item/StackProcessor.java
+++ b/src/main/java/me/timvinci/terrastorage/item/StackProcessor.java
@@ -2,7 +2,6 @@ package me.timvinci.terrastorage.item;
 
 import net.minecraft.world.item.ItemStack;
 
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
@@ -10,17 +9,16 @@ import java.util.function.Predicate;
  */
 public class StackProcessor {
     private final Predicate<ItemStack> shouldProcess;
-    private final Consumer<ItemStack> process;
+    private final Predicate<ItemStack> process;
 
-    public StackProcessor(Predicate<ItemStack> shouldProcess, Consumer<ItemStack> process) {
+    public StackProcessor(Predicate<ItemStack> shouldProcess, Predicate<ItemStack> process) {
         this.shouldProcess = shouldProcess;
         this.process = process;
     }
 
     public boolean tryProcess(ItemStack stack) {
         if (shouldProcess.test(stack)) {
-            process.accept(stack);
-            return true;
+            return process.test(stack);
         }
 
         return false;

--- a/src/main/java/me/timvinci/terrastorage/network/c2s/SortPayload.java
+++ b/src/main/java/me/timvinci/terrastorage/network/c2s/SortPayload.java
@@ -2,6 +2,7 @@ package me.timvinci.terrastorage.network.c2s;
 
 import me.timvinci.terrastorage.inventory.SlotBackedInventory;
 import me.timvinci.terrastorage.util.Reference;
+import me.timvinci.terrastorage.util.StorageMenuCompatibility;
 import me.timvinci.terrastorage.util.SortType;
 import me.timvinci.terrastorage.util.TerrastorageCore;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload.Type;
@@ -63,10 +64,19 @@ public record SortPayload(
             if (player.containerMenu == null || player.containerMenu.containerId != syncId.get()) {
                 return;
             }
+            if (StorageMenuCompatibility.shouldSkipStorageActions(player.containerMenu)) {
+                return;
+            }
 
             Container storageInventory;
             Slot firstSlot = player.containerMenu.slots.getFirst();
-            if (firstSlot.container.getContainerSize() != 0) {
+            if (StorageMenuCompatibility.shouldUseSlotBackedStorage(player.containerMenu)) {
+                List<Slot> nonPlayerSlots = player.containerMenu.slots.stream()
+                        .filter(slot -> !(slot.container instanceof Inventory))
+                        .toList();
+                storageInventory = new SlotBackedInventory(nonPlayerSlots);
+            }
+            else if (firstSlot.container.getContainerSize() != 0) {
                 if (!firstSlot.mayPickup(player)) {
                     player.sendSystemMessage(Component.translatable("terrastorage.message.restricted_inventory"));
                     return;

--- a/src/main/java/me/timvinci/terrastorage/network/c2s/StorageActionPayload.java
+++ b/src/main/java/me/timvinci/terrastorage/network/c2s/StorageActionPayload.java
@@ -2,6 +2,7 @@ package me.timvinci.terrastorage.network.c2s;
 
 import me.timvinci.terrastorage.inventory.SlotBackedInventory;
 import me.timvinci.terrastorage.util.Reference;
+import me.timvinci.terrastorage.util.StorageMenuCompatibility;
 import me.timvinci.terrastorage.util.StorageAction;
 import me.timvinci.terrastorage.util.TerrastorageCore;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload.Type;
@@ -63,10 +64,19 @@ public record StorageActionPayload(
             if (player.containerMenu == null || player.containerMenu.containerId != syncId.get()) {
                 return;
             }
+            if (StorageMenuCompatibility.shouldSkipStorageActions(player.containerMenu)) {
+                return;
+            }
 
             Container storageInventory;
             Slot firstSlot = player.containerMenu.slots.getFirst();
-            if (firstSlot.container.getContainerSize() != 0) {
+            if (StorageMenuCompatibility.shouldUseSlotBackedStorage(player.containerMenu)) {
+                List<Slot> nonPlayerSlots = player.containerMenu.slots.stream()
+                        .filter(slot -> !(slot.container instanceof Inventory))
+                        .toList();
+                storageInventory = new SlotBackedInventory(nonPlayerSlots);
+            }
+            else if (firstSlot.container.getContainerSize() != 0) {
                 if (!firstSlot.mayPickup(player)) {
                     player.sendSystemMessage(Component.translatable("terrastorage.message.restricted_inventory"));
                     return;
@@ -87,7 +97,7 @@ public record StorageActionPayload(
 
             switch (action) {
                 case LOOT_ALL -> TerrastorageCore.lootAll(player.getInventory(), storageInventory, hotbarProtection);
-                case DEPOSIT_ALL -> TerrastorageCore.depositAll(player.getInventory(), storageInventory, firstSlot, hotbarProtection);
+                case DEPOSIT_ALL -> TerrastorageCore.depositAll(player.getInventory(), storageInventory, hotbarProtection);
                 case QUICK_STACK -> TerrastorageCore.quickStack(player.getInventory(), storageInventory, hotbarProtection, smartDepositMode.get());
                 case RESTOCK -> TerrastorageCore.restock(player.getInventory(), storageInventory, hotbarProtection);
                 default -> throw new IllegalArgumentException("Unknown storage action: " + action);

--- a/src/main/java/me/timvinci/terrastorage/util/StorageMenuCompatibility.java
+++ b/src/main/java/me/timvinci/terrastorage/util/StorageMenuCompatibility.java
@@ -1,0 +1,40 @@
+package me.timvinci.terrastorage.util;
+
+import net.minecraft.world.inventory.AbstractContainerMenu;
+
+import java.util.Arrays;
+
+/**
+ * Compatibility checks for container menus that look like large storages but own custom slot rules.
+ */
+public final class StorageMenuCompatibility {
+    private static final String BACKPACKED_MENU_PACKAGE = "com.mrcrayfish.backpacked.inventory.container.";
+    private static final String BACKPACKED_BACKPACK_MENU = BACKPACKED_MENU_PACKAGE + "BackpackContainerMenu";
+    private static final String BACKPACKED_BACKPACK_MENU_PREFIX = BACKPACKED_MENU_PACKAGE + "Backpack";
+
+    private StorageMenuCompatibility() {}
+
+    public static boolean shouldSkipStorageActions(AbstractContainerMenu menu) {
+        if (menu == null) {
+            return false;
+        }
+
+        String menuClassName = menu.getClass().getName();
+        return menuClassName.startsWith(BACKPACKED_BACKPACK_MENU_PREFIX) && !menuClassName.equals(BACKPACKED_BACKPACK_MENU);
+    }
+
+    public static boolean shouldUseSlotBackedStorage(AbstractContainerMenu menu) {
+        return menu != null && menu.getClass().getName().equals(BACKPACKED_BACKPACK_MENU);
+    }
+
+    public static StorageAction[] getCompatibleButtonActions(AbstractContainerMenu menu, boolean isEnderChest) {
+        StorageAction[] actions = StorageAction.getButtonsActions(isEnderChest);
+        if (!shouldUseSlotBackedStorage(menu)) {
+            return actions;
+        }
+
+        return Arrays.stream(actions)
+                .filter(action -> action != StorageAction.RENAME)
+                .toArray(StorageAction[]::new);
+    }
+}

--- a/src/main/java/me/timvinci/terrastorage/util/TerrastorageCore.java
+++ b/src/main/java/me/timvinci/terrastorage/util/TerrastorageCore.java
@@ -17,7 +17,6 @@ import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.MenuProvider;
-import net.minecraft.world.inventory.Slot;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.network.chat.Component;
@@ -61,16 +60,15 @@ public class TerrastorageCore {
      * Attempts to deposit all the items from the player to the storage.
      * @param playerInventory The player's inventory.
      * @param storageInventory The storage's inventory.
-     * @param firstSlot The first slot of the screen handler of the storage inventory.
      * @param hotbarProtection The hotbar protection value of the player.
      */
-    public static void depositAll(Inventory playerInventory, Container storageInventory, Slot firstSlot, boolean hotbarProtection) {
+    public static void depositAll(Inventory playerInventory, Container storageInventory, boolean hotbarProtection) {
         // Create an inventory state from the storage's inventory.
         CompleteInventoryState storageInventoryState = new CompleteInventoryState(storageInventory);
 
         for (int i = Inventory.getSelectionSize(); i < playerInventory.getNonEquipmentItems().size(); i++) {
             ItemStack playerStack = playerInventory.getItem(i);
-            if (playerStack.isEmpty() || ItemFavoritingUtils.isFavorite(playerStack) || !firstSlot.mayPlace(playerStack)) {
+            if (playerStack.isEmpty() || ItemFavoritingUtils.isFavorite(playerStack)) {
                 continue;
             }
 
@@ -81,7 +79,7 @@ public class TerrastorageCore {
             for (int i = 0; i < Inventory.getSelectionSize(); i++) {
                 ItemStack playerStack = playerInventory.getItem(i);
 
-                if (playerStack.isEmpty() || ItemFavoritingUtils.isFavorite(playerStack) || !firstSlot.mayPlace(playerStack)) {
+                if (playerStack.isEmpty() || ItemFavoritingUtils.isFavorite(playerStack)) {
                     continue;
                 }
 
@@ -153,10 +151,16 @@ public class TerrastorageCore {
      */
     public static void sortStorageItems(Container storageInventory, SortType type) {
         List<ItemStack> sortedStacks = InventoryUtils.combineAndSortInventory(storageInventory, type, 0, storageInventory.getContainerSize(), false);
+        ArrayDeque<ItemStack> pendingStacks = new ArrayDeque<>(sortedStacks);
 
         int slotIndex = 0;
-        for (ItemStack stack : sortedStacks) {
-            storageInventory.setItem(slotIndex++, stack);
+        while (!pendingStacks.isEmpty() && slotIndex < storageInventory.getContainerSize()) {
+            ItemStack stack = pendingStacks.peekFirst();
+            if (storageInventory.canPlaceItem(slotIndex, stack)) {
+                storageInventory.setItem(slotIndex, pendingStacks.pollFirst());
+            }
+
+            slotIndex++;
         }
 
         storageInventory.setChanged();


### PR DESCRIPTION
## ✨ What changed

- Added compatibility handling for Backpacked backpack menus without adding a hard dependency on Backpacked.
- Uses the real menu slots for Backpacked backpacks through `SlotBackedInventory`, so Terrastorage respects locked slots, unlocked slots, and Backpacked slot placement rules.
- Keeps storage buttons available on the main Backpacked backpack screen, while hiding unsupported actions such as `Rename` there.
- Hardened stack transfers so source stacks are only reduced after the destination actually accepts the item.
- Updated quick stack processing to report whether a transfer really moved items, preventing false-positive animations or state updates.
- Made storage sorting respect `canPlaceItem` so sorting cannot force items into disallowed slots.

## 🧡 Why this helps

When a Backpacked backpack is opened, its menu can look like a normal large storage to Terrastorage. However, Backpacked uses custom unlockable slots. Locked or unavailable slots can appear empty from a generic container scan, but they should not accept items.

Before this change, `Deposit All` could treat those unavailable slots as valid empty space. In that path, Terrastorage could clear items from the player inventory before confirming that Backpacked accepted them, causing item loss when the backpack had no real available space.

This patch keeps the convenience of Terrastorage buttons for Backpacked backpacks while making the transfer path obey Backpacked slot rules.

## 🧪 Tested

- Verified in-game with Minecraft `26.1.2`, Fabric, and Backpacked `26.1.2 3.0.4`.
- Confirmed `Deposit All` no longer deletes items when the backpack has no valid available slots.
- Confirmed Terrastorage buttons still appear on the main Backpacked backpack screen.
- Ran `sh ./gradlew compileJava compileClientJava`.
- Ran `sh ./gradlew build`.

## 📦 Target

- Minecraft: `26.1.2`
- Loader: Fabric
- Compatibility target: Backpacked `26.1.2 3.0.4`

## 🤖 Transparency note

This solution was created with Codex as a development tool/assistant. I am mentioning this explicitly in case AI-assisted contributions matter for project review, maintainer preference, or contribution policy.