### PR TITLE
🧰 Respect container placement rules during transfers

### DIFF
--- a/src/main/java/me/timvinci/terrastorage/inventory/InventoryUtils.java
+++ b/src/main/java/me/timvinci/terrastorage/inventory/InventoryUtils.java
@@ -58,8 +58,12 @@ public class InventoryUtils {
             return;
         }
 
-        if (!receiverState.getEmptySlots().isEmpty()) {
+        while (!stack.isEmpty() && !receiverState.getEmptySlots().isEmpty()) {
             int emptySlot = receiverState.getEmptySlots().poll();
+            if (!to.getItem(emptySlot).isEmpty() || !to.canPlaceItem(emptySlot, stack)) {
+                continue;
+            }
+
             to.setItem(emptySlot, stack.copyAndClear());
             receiverState.setModified();
             // Check if the stack that was transferred isn't full.
@@ -67,6 +71,8 @@ public class InventoryUtils {
                 // Add this slot to the item slots of the receiver state.
                 receiverState.getNonFullItemSlots().computeIfAbsent(stackIdentifier, k -> new ArrayList<>()).add(emptySlot);
             }
+
+            break;
         }
     }
 
@@ -86,6 +92,10 @@ public class InventoryUtils {
         while (slotsIterator.hasNext() && !stackToTransfer.isEmpty()) {
             int slotWithItem = slotsIterator.next();
             ItemStack existingStack = to.getItem(slotWithItem);
+            if (!to.canPlaceItem(slotWithItem, stackToTransfer)) {
+                slotsIterator.remove();
+                continue;
+            }
 
             int spaceLeft = existingStack.getMaxStackSize() - existingStack.getCount();
             int transferAmount;

--- a/src/main/java/me/timvinci/terrastorage/inventory/SlotBackedInventory.java
+++ b/src/main/java/me/timvinci/terrastorage/inventory/SlotBackedInventory.java
@@ -54,7 +54,16 @@ public class SlotBackedInventory implements Container {
 
     @Override
     public void setItem(int slot, ItemStack stack) {
+        if (!stack.isEmpty() && !this.slots.get(slot).mayPlace(stack)) {
+            return;
+        }
+
         this.slots.get(slot).setByPlayer(stack);
+    }
+
+    @Override
+    public boolean canPlaceItem(int slot, ItemStack stack) {
+        return this.slots.get(slot).mayPlace(stack);
     }
 
     @Override


### PR DESCRIPTION
## ✨ What changed

- Checks `Container#canPlaceItem` before moving a stack into an empty destination slot.
- Continues scanning later empty slots when an earlier slot is unavailable, instead of treating the first empty-looking slot as usable.
- Makes `SlotBackedInventory` delegate placement checks to the backing `Slot#mayPlace` rule.
- Keeps the patch generic: no Backpacked-specific class checks, no new mod dependency, and no UI changes.

## 🧡 Why this helps

Some container menus can expose slots that look empty to a generic inventory scan but still reject inserted items through their normal placement rules. Backpacked backpacks are one example: locked backpack slots can appear empty, but they should not accept items.

Before this change, Terrastorage could select one of those empty-looking slots and clear the source stack while depositing, even though the destination slot was not actually valid. Respecting `canPlaceItem` keeps the transfer path aligned with the container API and avoids item loss.

## 🧪 Tested

- Verified in-game with Minecraft `26.1.2`, Fabric, and Backpacked `26.1.2 3.0.4`.
- Confirmed `Deposit All` no longer deletes items when the backpack has no valid available slots.
- Confirmed Terrastorage buttons still appear on the main Backpacked backpack screen.
- Ran `sh ./gradlew compileJava compileClientJava`.
- Ran `sh ./gradlew build`.

## 📦 Target

- Minecraft: `26.1.2`
- Loader: Fabric
- Compatibility case tested: Backpacked `26.1.2 3.0.4`

## 🔁 Replaces

- Replaces #63 with a smaller, generic patch that uses the existing container/slot APIs instead of explicit Backpacked compatibility checks.

## 🤖 Transparency note

This solution was created with Codex as a development tool/assistant. I am mentioning this explicitly in case AI-assisted contributions matter for project review, maintainer preference, or contribution policy.