### PR TITLE
Update to Minecraft 26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,10 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1
-minecraft_version_range=26.1-26.1.2
+minecraft_version=26.2
+minecraft_version_range=26.2
 loom_version = 1.15-SNAPSHOT
-loader_version=0.18.6
+loader_version=0.19.3
 
 # Mod Properties
 mod_version=1.2.7
@@ -18,6 +18,6 @@ maven_group=me.timvinci
 archives_base_name=Terrastorage
 
 # Dependencies
-fabric_api_version=0.145.1+26.1
+fabric_api_version=0.152.2+26.2
 night_config_version=3.8.1
-mod_menu_version=18.0.0-alpha.7
+mod_menu_version=20.0.0-beta.3

--- a/src/client/java/me/timvinci/terrastorage/command/TerrastorageClientCommands.java
+++ b/src/client/java/me/timvinci/terrastorage/command/TerrastorageClientCommands.java
@@ -20,7 +20,7 @@ public class TerrastorageClientCommands {
                     .executes(context -> {
                         Minecraft client = context.getSource().getClient();
                         client.schedule(() -> {
-                            client.setScreen(new TerrastorageOptionsScreen(client.screen));
+                            client.setScreenAndShow(new TerrastorageOptionsScreen(client.gui.screen()));
                         });
                         return 1;
                     })

--- a/src/client/java/me/timvinci/terrastorage/config/ClientConfigManager.java
+++ b/src/client/java/me/timvinci/terrastorage/config/ClientConfigManager.java
@@ -7,7 +7,7 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Tuple;
+import com.mojang.datafixers.util.Pair;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -44,7 +44,7 @@ public class ClientConfigManager extends BaseConfigManager<TerrastorageClientCon
      * @return A list of ClickableWidgets, containing the buttons.
      */
     @SuppressWarnings("unchecked")
-    public List<Tuple<AbstractWidget, Boolean>> asOptions() {
+    public List<Pair<AbstractWidget, Boolean>> asOptions() {
         List<AbstractWidget> options = new ArrayList<>();
         List<Boolean> singleOptionOrder = new ArrayList<>();
         int i = 0;
@@ -107,9 +107,9 @@ public class ClientConfigManager extends BaseConfigManager<TerrastorageClientCon
             }
         }
 
-        List<Tuple<AbstractWidget, Boolean>> result = new ArrayList<>();
+        List<Pair<AbstractWidget, Boolean>> result = new ArrayList<>();
         for (int j = 0; j < options.size(); j++) {
-            result.add(new Tuple<>(options.get(j), singleOptionOrder.get(j)));
+            result.add(Pair.of(options.get(j), singleOptionOrder.get(j)));
         }
 
         return result;

--- a/src/client/java/me/timvinci/terrastorage/gui/ButtonsCustomizationScreen.java
+++ b/src/client/java/me/timvinci/terrastorage/gui/ButtonsCustomizationScreen.java
@@ -543,6 +543,6 @@ public class ButtonsCustomizationScreen extends Screen {
 
     @Override
     public void onClose(){
-        this.minecraft.setScreen(this.parent);
+        this.minecraft.setScreenAndShow(this.parent);
     }
 }

--- a/src/client/java/me/timvinci/terrastorage/gui/RenameScreen.java
+++ b/src/client/java/me/timvinci/terrastorage/gui/RenameScreen.java
@@ -76,7 +76,7 @@ public class RenameScreen extends Screen {
     @Override
     public void onClose() {
         // Set the screen to the parent screen when this screen is closed.
-        this.minecraft.setScreen(parent);
+        this.minecraft.setScreenAndShow(parent);
     }
 
     /**

--- a/src/client/java/me/timvinci/terrastorage/gui/TerrastorageOptionsScreen.java
+++ b/src/client/java/me/timvinci/terrastorage/gui/TerrastorageOptionsScreen.java
@@ -9,7 +9,7 @@ import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Tuple;
+import com.mojang.datafixers.util.Pair;
 
 import java.util.Iterator;
 import java.util.List;
@@ -29,19 +29,19 @@ public class TerrastorageOptionsScreen extends OptionsSubScreen {
     @Override
     protected void addOptions() {
         if (this.list != null) {
-            List<Tuple<AbstractWidget, Boolean>> options = ClientConfigManager.getInstance().asOptions();
-            options.add(3, new Tuple<>(getButtonsCustomizationButton(), false));
-            Iterator<Tuple<AbstractWidget, Boolean>> iterator = options.iterator();
+            List<Pair<AbstractWidget, Boolean>> options = ClientConfigManager.getInstance().asOptions();
+            options.add(3, Pair.of(getButtonsCustomizationButton(), false));
+            Iterator<Pair<AbstractWidget, Boolean>> iterator = options.iterator();
 
             while (iterator.hasNext()) {
-                Tuple<AbstractWidget, Boolean> current = iterator.next();
+                Pair<AbstractWidget, Boolean> current = iterator.next();
 
-                if (current.getB()) {
-                    current.getA().setWidth(310);
-                    this.list.addSmall(current.getA(), null);
+                if (current.getSecond()) {
+                    current.getFirst().setWidth(310);
+                    this.list.addSmall(current.getFirst(), null);
                 } else {
-                    AbstractWidget secondWidget = iterator.hasNext() ? iterator.next().getA() : null;
-                    this.list.addSmall(current.getA(), secondWidget);
+                    AbstractWidget secondWidget = iterator.hasNext() ? iterator.next().getFirst() : null;
+                    this.list.addSmall(current.getFirst(), secondWidget);
                 }
             }
         }

--- a/src/client/java/me/timvinci/terrastorage/gui/TerrastorageOptionsScreen.java
+++ b/src/client/java/me/timvinci/terrastorage/gui/TerrastorageOptionsScreen.java
@@ -49,7 +49,7 @@ public class TerrastorageOptionsScreen extends OptionsSubScreen {
 
     private Button getButtonsCustomizationButton() {
         return Button.builder(Component.translatable("terrastorage.button.buttons_customization"),
-                onPress -> Minecraft.getInstance().setScreen(new ButtonsCustomizationScreen(Minecraft.getInstance().screen)))
+                onPress -> Minecraft.getInstance().setScreenAndShow(new ButtonsCustomizationScreen(Minecraft.getInstance().gui.screen())))
         .tooltip(Tooltip.create(Component.translatable("terrastorage.button.tooltip.buttons_customization"))).build();
     }
 
@@ -62,6 +62,6 @@ public class TerrastorageOptionsScreen extends OptionsSubScreen {
         if (!ClientConfigManager.getInstance().saveConfig() && Minecraft.getInstance().player != null) {
             Minecraft.getInstance().player.sendSystemMessage(TextStyler.error("terrastorage.message.client_saving_error"));
         }
-        this.minecraft.setScreen(this.lastScreen);
+        this.minecraft.setScreenAndShow(this.lastScreen);
     }
 }

--- a/src/client/java/me/timvinci/terrastorage/gui/widget/StorageButtonCreator.java
+++ b/src/client/java/me/timvinci/terrastorage/gui/widget/StorageButtonCreator.java
@@ -37,9 +37,9 @@ public class StorageButtonCreator {
             case SORT_ITEMS -> button -> ClientNetworkHandler.sendSortPayload(false);
             case RENAME -> button -> {
                 Minecraft client = Minecraft.getInstance();
-                String name = client.screen.getTitle().getString();
+                String name = client.gui.screen().getTitle().getString();
                 client.execute(() -> {
-                    client.setScreen(new RenameScreen(client.screen, name));
+                    client.setScreenAndShow(new RenameScreen(client.gui.screen(), name));
                 });
             };
             default -> button -> ClientNetworkHandler.sendActionPayload(action);

--- a/src/client/java/me/timvinci/terrastorage/gui/widget/StorageButtonCreator.java
+++ b/src/client/java/me/timvinci/terrastorage/gui/widget/StorageButtonCreator.java
@@ -14,7 +14,7 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.ImageButton;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
-import net.minecraft.util.Tuple;
+import com.mojang.datafixers.util.Pair;
 
 import java.util.Locale;
 
@@ -82,7 +82,7 @@ public class StorageButtonCreator {
      * @param y The y position.
      * @return A pair of the inventory TexturedButtonWidgets.
      */
-    public static Tuple<ImageButton, ImageButton> createInventoryButtons(int x, int y) {
+    public static Pair<ImageButton, ImageButton> createInventoryButtons(int x, int y) {
         WidgetSprites quickStackTexture = getButtonTextures("quick_stack");
         WidgetSprites sortInventoryTexture = getButtonTextures("sort_inventory");
         ImageButton quickStackButton = new ImageButton(
@@ -105,7 +105,7 @@ public class StorageButtonCreator {
         );
         sortInventoryButton.setTooltip(Tooltip.create(Component.translatable("terrastorage.button.tooltip.sort_inventory")));
 
-        return new Tuple<>(quickStackButton, sortInventoryButton);
+        return Pair.of(quickStackButton, sortInventoryButton);
     }
 
     private static WidgetSprites getButtonTextures(String buttonName) {

--- a/src/client/java/me/timvinci/terrastorage/mixin/client/AbstractContainerScreenMixin.java
+++ b/src/client/java/me/timvinci/terrastorage/mixin/client/AbstractContainerScreenMixin.java
@@ -100,7 +100,7 @@ public abstract class AbstractContainerScreenMixin<T extends AbstractContainerMe
                             Component.translatable("terrastorage.button.options"),
                             onPress -> {
                                 minecraft.execute(() -> {
-                                    minecraft.setScreen(new TerrastorageOptionsScreen(minecraft.screen));
+                                    minecraft.setScreenAndShow(new TerrastorageOptionsScreen(minecraft.gui.screen()));
                                 });
                             })
                     .size(120, 15)

--- a/src/client/java/me/timvinci/terrastorage/mixin/client/CreativeModeInventoryScreenMixin.java
+++ b/src/client/java/me/timvinci/terrastorage/mixin/client/CreativeModeInventoryScreenMixin.java
@@ -16,7 +16,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Tuple;
+import com.mojang.datafixers.util.Pair;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -124,11 +124,11 @@ public abstract class CreativeModeInventoryScreenMixin extends AbstractContainer
     private void onInit(CallbackInfo ci) {
         int buttonX = this.leftPos + 138;
         int buttonY = this.topPos + 19;
-        Tuple<ImageButton, ImageButton> buttons = StorageButtonCreator.createInventoryButtons(buttonX, buttonY);
-        quickStackButton = buttons.getA();
+        Pair<ImageButton, ImageButton> buttons = StorageButtonCreator.createInventoryButtons(buttonX, buttonY);
+        quickStackButton = buttons.getFirst();
         this.addRenderableWidget(quickStackButton);
 
-        sortInventoryButton = buttons.getB();
+        sortInventoryButton = buttons.getSecond();
         this.addRenderableWidget(sortInventoryButton);
     }
 

--- a/src/client/java/me/timvinci/terrastorage/mixin/client/GuiMixin.java
+++ b/src/client/java/me/timvinci/terrastorage/mixin/client/GuiMixin.java
@@ -9,7 +9,7 @@ import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.Hud;
 import net.minecraft.client.DeltaTracker;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.world.entity.player.Player;
@@ -25,7 +25,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 /**
  * A mixin of the Gui class, used for adding item favoriting support.
  */
-@Mixin(Gui.class)
+@Mixin(Hud.class)
 public class GuiMixin {
     @Unique
     private final Identifier favoriteBorder = Identifier.fromNamespaceAndPath(Reference.MOD_ID, "textures/gui/sprites/favorite_border.png");

--- a/src/client/java/me/timvinci/terrastorage/mixin/client/InventoryScreenMixin.java
+++ b/src/client/java/me/timvinci/terrastorage/mixin/client/InventoryScreenMixin.java
@@ -9,7 +9,7 @@ import net.minecraft.client.gui.components.ImageButton;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Tuple;
+import com.mojang.datafixers.util.Pair;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -43,11 +43,11 @@ public abstract class InventoryScreenMixin extends AbstractRecipeBookScreen<Inve
 
         int buttonX = this.leftPos + 128;
         int buttonY = this.height / 2 - 22;
-        Tuple<ImageButton, ImageButton> buttons = StorageButtonCreator.createInventoryButtons(buttonX, buttonY);
-        quickStackButton = buttons.getA();
+        Pair<ImageButton, ImageButton> buttons = StorageButtonCreator.createInventoryButtons(buttonX, buttonY);
+        quickStackButton = buttons.getFirst();
         this.addRenderableWidget(quickStackButton);
 
-        sortInventoryButton = buttons.getB();
+        sortInventoryButton = buttons.getSecond();
         this.addRenderableWidget(sortInventoryButton);
     }
 

--- a/src/client/java/me/timvinci/terrastorage/mixin/client/LevelRendererMixin.java
+++ b/src/client/java/me/timvinci/terrastorage/mixin/client/LevelRendererMixin.java
@@ -6,12 +6,16 @@ import net.minecraft.client.renderer.state.level.LevelRenderState;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.RenderBuffers;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.ShaderManager;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.client.resources.model.sprite.AtlasManager;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.SubmitNodeStorage;
-import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -39,20 +43,20 @@ public class LevelRendererMixin {
     @Final
     @Shadow
     private BlockEntityRenderDispatcher blockEntityRenderDispatcher;
-    @Shadow
-    @Nullable
-    private ClientLevel level;
 
     /**
      * Initiates the nametag renderer.
      */
     @Inject(method = "<init>", at = @At("TAIL"))
-    private void onInit(Minecraft minecraft,
-                        EntityRenderDispatcher entityRenderDispatcher,
+    private void onInit(EntityRenderDispatcher entityRenderDispatcher,
                         BlockEntityRenderDispatcher blockEntityRenderDispatcher,
-                        RenderBuffers renderBuffers,
-                        GameRenderState gameRenderState,
-                        FeatureRenderDispatcher featureRenderDispatcher,
+                        ModelManager modelManager,
+                        TextureManager textureManager,
+                        AtlasManager atlasManager,
+                        ShaderManager shaderManager,
+                        GameRenderer gameRenderer,
+                        int i,
+                        int j,
                         CallbackInfo ci) {
         nametagRenderer = new NametagRenderer(Minecraft.getInstance().font);
     }
@@ -72,7 +76,7 @@ public class LevelRendererMixin {
     private void afterRenderBlockEntity(
             PoseStack poseStack,
             LevelRenderState levelRenderState,
-            SubmitNodeStorage submitNodeStorage,
+            SubmitNodeCollector submitNodeCollector,
             CallbackInfo ci,
             Vec3 vec3d,
             double d,
@@ -81,6 +85,7 @@ public class LevelRendererMixin {
             Iterator<BlockEntityRenderState> iterator,
             BlockEntityRenderState blockEntityRenderState
     ) {
+        ClientLevel level = Minecraft.getInstance().level;
         if (level == null)
             return;
 
@@ -94,6 +99,6 @@ public class LevelRendererMixin {
                 || !nametagRenderer.hasLabel(container, Minecraft.getInstance().hitResult))
             return;
 
-        nametagRenderer.renderNametag(blockPos, container.getCustomName(), level, poseStack, submitNodeStorage, levelRenderState.cameraRenderState);
+        nametagRenderer.renderNametag(blockPos, container.getCustomName(), level, poseStack, (SubmitNodeStorage) submitNodeCollector, levelRenderState.cameraRenderState);
     }
 }

--- a/src/client/java/me/timvinci/terrastorage/render/NametagRenderer.java
+++ b/src/client/java/me/timvinci/terrastorage/render/NametagRenderer.java
@@ -4,7 +4,7 @@ import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -57,7 +57,7 @@ public class NametagRenderer {
             renderPos = renderPos.add(0, 1, 0);
 
 
-        int light = LevelRenderer.getLightCoords(level, BlockPos.containing(renderPos));
+        int light = LightCoordsUtil.getLightCoords(level, BlockPos.containing(renderPos));
 
         poseStack.pushPose();
         poseStack.translate(

--- a/src/client/java/me/timvinci/terrastorage/util/ScreenInteractionUtils.java
+++ b/src/client/java/me/timvinci/terrastorage/util/ScreenInteractionUtils.java
@@ -31,7 +31,7 @@ public class ScreenInteractionUtils {
         }
 
         boolean cancel = switch (containerInput) {
-            case QUICK_MOVE -> ItemFavoritingUtils.isFavorite(slot.getItem()) && !(client.screen instanceof InventoryScreen || client.screen instanceof CreativeModeInventoryScreen);
+            case QUICK_MOVE -> ItemFavoritingUtils.isFavorite(slot.getItem()) && !(client.gui.screen() instanceof InventoryScreen || client.gui.screen() instanceof CreativeModeInventoryScreen);
             case THROW -> ItemFavoritingUtils.isFavorite(slot.getItem());
             case SWAP -> !(slot.container instanceof Inventory) && ItemFavoritingUtils.isFavorite(client.player.getInventory().getItem(button));
             default -> false;

--- a/src/main/java/me/timvinci/terrastorage/inventory/InventoryUtils.java
+++ b/src/main/java/me/timvinci/terrastorage/inventory/InventoryUtils.java
@@ -23,7 +23,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.util.Tuple;
+import com.mojang.datafixers.util.Pair;
 import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -184,9 +184,9 @@ public class InventoryUtils {
      * @param player The player.
      * @return A list consisting of pairs of inventories and their position.
      */
-    public static List<Tuple<Container, Vec3>> getNearbyStorages(ServerPlayer player) {
+    public static List<Pair<Container, Vec3>> getNearbyStorages(ServerPlayer player) {
         Level world = player.level();
-        List<Tuple<Container, Vec3>> nearbyStorages = new ArrayList<>();
+        List<Pair<Container, Vec3>> nearbyStorages = new ArrayList<>();
         Set<BlockPos> processedChests = new HashSet<>();
 
         // Getting the range, and whether the los check is enabled.
@@ -219,28 +219,28 @@ public class InventoryUtils {
                     }
                 }
                 else {
-                    losPoint = pos.getCenter();
+                    losPoint = Vec3.atCenterOf(pos);
                 }
 
                 if (blockEntity instanceof ChestBlockEntity) {
                     ChestType chestType = state.getValue(ChestBlock.TYPE);
                     if (chestType == ChestType.SINGLE) {
-                        nearbyStorages.add(new Tuple<>(inventory, losPoint));
+                        nearbyStorages.add(Pair.of(inventory, losPoint));
                         return;
                     }
 
                     BlockPos neighboringChestPos = getNeighboringChestPos(pos, chestType, state.getValue(ChestBlock.FACING));
-                    Vec3 doubleChestLosPoint = getDoubleChestCenter(losPoint, neighboringChestPos.getCenter());
+                    Vec3 doubleChestLosPoint = getDoubleChestCenter(losPoint, Vec3.atCenterOf(neighboringChestPos));
                     Container neighboringChestInventory = (Container) world.getBlockEntity(neighboringChestPos);
 
                     CompoundContainer doubleInventory = chestType == ChestType.RIGHT ?
                             new CompoundContainer(inventory, neighboringChestInventory) :
                             new CompoundContainer(neighboringChestInventory, inventory);
-                    nearbyStorages.add(new Tuple<>(doubleInventory, doubleChestLosPoint));
+                    nearbyStorages.add(Pair.of(doubleInventory, doubleChestLosPoint));
                     processedChests.add(neighboringChestPos);
                 }
                 else {
-                    nearbyStorages.add(new Tuple<>(inventory, losPoint));
+                    nearbyStorages.add(Pair.of(inventory, losPoint));
                 }
             }
         });
@@ -260,7 +260,7 @@ public class InventoryUtils {
                     losPoint = entity.getBoundingBox().getCenter();
                 }
 
-                nearbyStorages.add(new Tuple<>((Container) entity, losPoint));
+                nearbyStorages.add(Pair.of((Container) entity, losPoint));
             }
         );
 
@@ -300,7 +300,7 @@ public class InventoryUtils {
      */
     private static Vec3 hasLineOfSight(ServerPlayer player, Level world, BlockPos pos) {
         Vec3 playerEyes = player.getEyePosition();
-        Vec3 centerPos = pos.getCenter();
+        Vec3 centerPos = Vec3.atCenterOf(pos);
 
         // Define the points to check (center, top center, bottom center)
         Vec3[] pointsToCheck = new Vec3[] {

--- a/src/main/java/me/timvinci/terrastorage/util/TerrastorageCore.java
+++ b/src/main/java/me/timvinci/terrastorage/util/TerrastorageCore.java
@@ -21,7 +21,7 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Tuple;
+import com.mojang.datafixers.util.Pair;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.*;
@@ -271,7 +271,7 @@ public class TerrastorageCore {
      * @param smartDepositMode Whether the player's quick stack mode is 'smart deposit'.
      */
     public static void quickStackToNearbyStorages(ServerPlayer player, boolean hotbarProtection, boolean smartDepositMode) {
-        List<Tuple<Container, Vec3>> nearbyStorages = InventoryUtils.getNearbyStorages(player);
+        List<Pair<Container, Vec3>> nearbyStorages = InventoryUtils.getNearbyStorages(player);
         if (nearbyStorages.isEmpty()) {
             return;
         }
@@ -283,9 +283,9 @@ public class TerrastorageCore {
         int startIndex = hotbarProtection ? Inventory.getSelectionSize() : 0;
         boolean playerInventoryModified = false;
 
-        for (Tuple<Container, Vec3> storagePair : nearbyStorages) {
-            Container storage = storagePair.getA();
-            Vec3 storagePos = storagePair.getB();
+        for (Pair<Container, Vec3> storagePair : nearbyStorages) {
+            Container storage = storagePair.getFirst();
+            Vec3 storagePos = storagePair.getSecond();
 
             InventoryState storageState = stateFactory.apply(storage);
             StackProcessor processor = InventoryUtils.createStackProcessor(storageState, storage, smartDepositMode);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,9 +34,9 @@
 		}
 	],
 	"depends": {
-		"fabricloader": ">=0.18.4",
-		"minecraft": ">=26.1 <=26.1.2",
+		"fabricloader": ">=0.19.3",
+		"minecraft": "~26.2",
 		"java": ">=25",
-		"fabric-api": ">=0.144.0"
+		"fabric-api": ">=0.152.0"
 	}
 }


### PR DESCRIPTION
Updates Terrastorage to Minecraft 26.2.

Commits are split per API migration for easier review:

1. **Update to Minecraft 26.2** — bumps Fabric loader (`0.19.3`), Fabric API (`0.152.2+26.2`) and Mod Menu (`20.0.0-beta.3`), and the dependency ranges in `fabric.mod.json`.
2. **Replace removed Tuple and BlockPos.getCenter** — `net.minecraft.util.Tuple` and `BlockPos#getCenter` were removed; nearby-storage pairs now use `com.mojang.datafixers.util.Pair` and block centers use `Vec3.atCenterOf`.
3. **Migrate screen access to setScreenAndShow and Gui.screen()** — `Minecraft#setScreen` and the public `Minecraft.screen` field are gone; the active screen now lives on `Gui`.
4. **Move nametag light lookup to LightCoordsUtil** — `LevelRenderer#getLightCoords` was relocated to `net.minecraft.util.LightCoordsUtil`.
5. **Update LevelRendererMixin for the new render pipeline** — `LevelRenderer` no longer holds a `ClientLevel` field, its constructor signature changed, and `submitBlockEntities` now takes a `SubmitNodeCollector`.
6. **Retarget hotbar slot mixin from Gui to Hud** — hotbar `extractSlot` rendering moved from `Gui` to the new `Hud` class (identical signature).

## Testing
- `./gradlew build` passes.
- Launched in a Fabric 26.2 instance: reaches the main menu with no mixin/injection errors, and thesorting, quick-stack-to-nearby screens work in-game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)